### PR TITLE
Error window for crash reporting

### DIFF
--- a/PPT-Sandbox/App.xaml
+++ b/PPT-Sandbox/App.xaml
@@ -4,7 +4,7 @@
              xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
              StartupUri="UI.xaml"
              Startup="Main">
-    
+
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -13,6 +13,18 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseDark.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Cyan.xaml" />
+
+                <ResourceDictionary>
+                    <Style x:Key="SandboxWindow" TargetType="Controls:MetroWindow">
+                        <Setter Property="TitleCharacterCasing" Value="Normal" />
+                        <Setter Property="ResizeMode" Value="NoResize" />
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="Background" Value="#0A0A0A" />
+                        <Setter Property="Foreground" Value="#DCDCDC" />
+                        <Setter Property="GlowBrush" Value="{DynamicResource AccentColorBrush}" />
+                        <Setter Property="SizeToContent" Value="Height" />
+                    </Style>
+                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/PPT-Sandbox/App.xaml.cs
+++ b/PPT-Sandbox/App.xaml.cs
@@ -1,9 +1,14 @@
-﻿using System.Globalization;
+﻿﻿using System;
+using System.Globalization;
+using System.Reflection;
 using System.Threading;
 using System.Windows;
 
 namespace Sandbox {
     public partial class App {
+        public static readonly int Version = Assembly.GetExecutingAssembly().GetName().Version.Minor;
+        public static readonly string VersionString = $"PPT-Sandbox-{Version}";
+
 #if DEBUG
         void OverrideLocale(string locale) =>
             Thread.CurrentThread.CurrentCulture = Thread.CurrentThread.CurrentUICulture = new CultureInfo(locale);
@@ -13,6 +18,11 @@ namespace Sandbox {
 #if DEBUG
             OverrideLocale("en-US");
 #endif
+
+            AppDomain.CurrentDomain.UnhandledException += (s, ex) => {
+                new Error(ex.ExceptionObject.ToString()).ShowDialog();
+                Current.Shutdown();
+            };
         }
     }
 }

--- a/PPT-Sandbox/Error.xaml
+++ b/PPT-Sandbox/Error.xaml
@@ -1,0 +1,24 @@
+﻿<Controls:MetroWindow x:Class="Sandbox.Error"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
+                      Style="{StaticResource SandboxWindow}"
+                      Title="PPT-Sandbox Error" WindowStartupLocation="CenterScreen"
+                      SizeToContent="Manual" Width="600" Height="400">
+
+    <Grid Margin="15 10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Margin="0 0 0 5" x:Name="General" />
+
+        <Border Grid.Row="1" Margin="0 0 0 5" BorderBrush="#202020" Height="1" BorderThickness="0 0 0 1" />
+
+        <TextBox Grid.Row="2" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Visible" ScrollViewer.CanContentScroll="True"
+                 x:Name="Exception" />
+    </Grid>
+</Controls:MetroWindow>

--- a/PPT-Sandbox/Error.xaml.cs
+++ b/PPT-Sandbox/Error.xaml.cs
@@ -7,7 +7,7 @@ namespace Sandbox {
 
             switch (CultureInfo.CurrentCulture.TwoLetterISOLanguageName) {
                 case "ko":
-                    General.Text = "";
+                    General.Text = "PPT-Sandbox에 에러가 발생했습니다. 아래의 정보를 개발자에게 신고해주세요.";
                     break;
                     
                 case "ja":

--- a/PPT-Sandbox/Error.xaml.cs
+++ b/PPT-Sandbox/Error.xaml.cs
@@ -1,0 +1,25 @@
+﻿﻿using System.Globalization;
+
+namespace Sandbox {
+    public partial class Error {
+        public Error(string exceptionText) {
+            InitializeComponent();
+
+            switch (CultureInfo.CurrentCulture.TwoLetterISOLanguageName) {
+                case "ko":
+                    General.Text = "";
+                    break;
+                    
+                case "ja":
+                    General.Text = "エラーが発生しました。以下の情報を開発者に報告してください。";
+                    break;
+                    
+                default:
+                    General.Text = "PPT-Sandbox has encountered an error. Please report the information below to the developers.";
+                    break;
+            }
+
+            Exception.Text = $"Version: {App.VersionString}\n\n{exceptionText}";
+        }
+    }
+}

--- a/PPT-Sandbox/PPT-Sandbox.csproj
+++ b/PPT-Sandbox/PPT-Sandbox.csproj
@@ -87,6 +87,9 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="OptionalRadioButton.cs" />
+    <Compile Include="Error.xaml.cs">
+      <DependentUpon>Error.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI.xaml.cs">
       <DependentUpon>UI.xaml</DependentUpon>
     </Compile>
@@ -101,6 +104,10 @@
     <Compile Include="Dial.xaml.cs">
       <DependentUpon>Dial.xaml</DependentUpon>
     </Compile>
+    <Page Include="Error.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="UI.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/PPT-Sandbox/UI.xaml
+++ b/PPT-Sandbox/UI.xaml
@@ -3,10 +3,8 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:Controls="http://metro.mahapps.com/winfx/xaml/controls"
                       xmlns:Sandbox="clr-namespace:Sandbox"
-                      TitleCharacterCasing="Normal" Title="PPT-Sandbox"
-                      WindowStartupLocation="CenterScreen"
-                      Width="500" SizeToContent="Height" BorderThickness="0" ResizeMode="NoResize"
-                      Background="#0A0A0A" Foreground="#DCDCDC" GlowBrush="{DynamicResource AccentColorBrush}">
+                      Style="{StaticResource SandboxWindow}"
+                      Title="PPT-Sandbox" WindowStartupLocation="CenterScreen" Width="500">
 
     <Grid>
         <StackPanel Margin="5 10">

--- a/PPT-Sandbox/UI.xaml.cs
+++ b/PPT-Sandbox/UI.xaml.cs
@@ -20,8 +20,6 @@ namespace Sandbox {
         private Dictionary<UniformGrid, Action<int, int>> TableScripts;
         private List<object> EncodingList;
 
-        static readonly int Version = Assembly.GetExecutingAssembly().GetName().Version.Minor;
-
         private byte[] ConvertByteString(string bytes) =>
             bytes.Split(' ').Select(i => Convert.ToByte(i, 16)).ToArray();
 
@@ -31,7 +29,7 @@ namespace Sandbox {
 
             ToolTipService.ShowDurationProperty.OverrideMetadata(typeof(DependencyObject), new FrameworkPropertyMetadata(Int32.MaxValue)); //tooltips no longer yeet after 5 seconds
 
-            VersionText.Text = $"PPT-Sandbox-{Version} by {FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).CompanyName}";
+            VersionText.Text = $"{App.VersionString} by {FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).CompanyName}";
 
             switch (CultureInfo.CurrentCulture.TwoLetterISOLanguageName) {
                 case "ko":
@@ -2387,7 +2385,7 @@ namespace Sandbox {
             if (!reader.ReadBytes(4).Select(i => (char)i).SequenceEqual(new char[] {'P', 'T', 'S', 'B'}))
                 throw new InvalidDataException("The selected file is not a PPT-Sandbox file.");
 
-            if (reader.ReadInt32() != Version)
+            if (reader.ReadInt32() != App.Version)
                 throw new InvalidDataException("The version of the file doesn't match the version of PPT-Sandbox.");
         }
 


### PR DESCRIPTION
If PPT-Sandbox itself crashes, it'll now show a crash log window.

![image](https://user-images.githubusercontent.com/13300194/75458058-87105500-597d-11ea-8419-e176e77dbee1.png)

To test, find a crash lmao or put `throw new Exception("Testing crash...");` in a button handler like `public void Reset(object sender, RoutedEventArgs e)`